### PR TITLE
fix demo.py: need to convert BGR to RGB after reading an image

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -23,6 +23,7 @@ args = parser.parse_args()
 
 # read image
 img = cv2.imread(args.img)
+img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 with torch.no_grad():
     out = net(T.ToTensor()(img).unsqueeze(0))
     conf_scores = out.squeeze(0).data.numpy()


### PR DESCRIPTION
Hi professor. today I was testing `demo.py` in this repo and found it performed strangely.
At first I tested it on [LFW(Labeled Faces in the Wild)](http://vis-www.cs.umass.edu/lfw/) (Note: need to `resize()` images to `128*128`). And the threshold for classification is 0.5. As far as I know, LFW is a very basic test dataset in face recognition field. However, I got results as following:
```
Total: 13233
Correctly Recognized: 9913
Accuracy: 74.91%
```
And for my program in project 5:
```
Total: 13233
Correctly Recognized: 13192
Accuracy: 99.69%
```
Therefore, I started to doubt why my program outperformed than the given demo.
Then I tested a picture of Professor Yu's face (some classmate posted in our QQ group):
![face2](https://user-images.githubusercontent.com/57553691/146643695-c2968af3-315f-4361-a549-842b3c9f27e8.jpg)
And I got the following result:
```
bg score: 0.618272, face score: 0.381728.
```
, which is incorrect.

---

I noticed that an anonymous classmate in our QQ group mentioned that `demo.py` keeps the BGR order after reading an image. Thus, I tried to convert it to RGB, and then every thing went normal.
Same image after BGR2RGB:
```
bg score: 0.000000, face score: 1.000000.
```
LFW test results:
```
Total: 13233
Correctly Recognized: 13192
Accuracy: 99.69%
```
Exactly same as my program.

The changes are:
```python
# ...
# read image
img = cv2.imread(args.img)
img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) # <----- added this line
# ...
```

So is it really wrong? Do we need BGR2RGB? Or I missed anything?
If I mistook, please feel free to close this PR, thanks.

11812804 Dong Zheng
2021-12-18